### PR TITLE
Fixes for multiple, differently-sized displays

### DIFF
--- a/src/Dragger.cs
+++ b/src/Dragger.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Windows;
+using System.Windows.Forms;
 using System.Windows.Input;
 using System.Windows.Media;
 
@@ -9,9 +10,39 @@ namespace Rooler {
 		private FrameworkElement target;
 		private TranslateTransform offset = new TranslateTransform();
 		private Point lastMousePt;
-		
+
 		public Dragger(FrameworkElement target) {
 			this.target = target;
+
+			this.target.Loaded += (sender, args) =>
+			{
+				// Calculate the offset:
+				// With multiple displays, depending their relative positioning,
+				// simply centering the target at the top may be outside the visual area.
+				var currentScreen = Screen.FromPoint(System.Windows.Forms.Cursor.Position);
+				var fullScreen = ScreenShot.FullScreenBounds;
+
+				var centerOfAllScreensX = fullScreen.Width/2.0;
+				var centerOfAllScreensY = (double)fullScreen.Top;
+
+				var centerOfCurrentScreenX = currentScreen.Bounds.Left + currentScreen.Bounds.Width/2;
+				var centerOfCurrentScreenY = currentScreen.Bounds.Top;
+
+				// Calculate the offset (difference between the top-center of all screens and that of the current screen.
+				var xOffset = centerOfCurrentScreenX - centerOfAllScreensX;
+				var yOffset = centerOfCurrentScreenY - centerOfAllScreensY;
+
+				// Transform the WinForms pixels (system dpi) to WPF pixels (based on virtual 96dpi).
+				var source = PresentationSource.FromVisual(target);
+				if (source?.CompositionTarget != null)
+				{
+					xOffset = xOffset / source.CompositionTarget.TransformToDevice.M11;
+					yOffset = yOffset / source.CompositionTarget.TransformToDevice.M22;
+				}
+
+				this.offset.X = xOffset;
+				this.offset.Y = yOffset;
+			};
 
 			this.target.RenderTransform = this.offset;
 
@@ -34,7 +65,7 @@ namespace Rooler {
 			this.target.ReleaseMouseCapture();
 		}
 
-		private void HandleMouseMove(object sender, MouseEventArgs e) {
+		private void HandleMouseMove(object sender, System.Windows.Input.MouseEventArgs e) {
 			if (this.target.IsMouseCaptured) {
 				Point point = e.GetPosition(this.target);
 

--- a/src/MainWindow.xaml
+++ b/src/MainWindow.xaml
@@ -1,6 +1,6 @@
 ﻿<Window
-    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+		xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+		xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 		xmlns:d="http://schemas.microsoft.com/expression/blend/2008" xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" mc:Ignorable="d" xmlns:Microsoft_Windows_Themes="clr-namespace:Microsoft.Windows.Themes;assembly=PresentationFramework.Aero" x:Class="Rooler.MainWindow"
 		WindowStyle='None'
 	AllowsTransparency='True'
@@ -8,7 +8,7 @@
 	Background='#0000FF00'
 	Foreground="#FFFFFFFF">
 	<!--Background='#00FFFFFF'-->
-	
+
 	<Window.Resources>
 		<LinearGradientBrush x:Key="MouseOverBackground" EndPoint="0.5,1" StartPoint="0.5,0">
 			<GradientStop Color="#FF797979" Offset="0.504"/>
@@ -37,7 +37,7 @@
 				<Trigger Property="IsMouseOver" Value="True">
 					<Setter Property="Background" Value="{DynamicResource MouseOverBackground}"/>
 				</Trigger>
-				
+
 			</Style.Triggers>
 		</Style>
 		<SolidColorBrush x:Key="Redline" Color="#FFE40000"/>
@@ -445,8 +445,8 @@
 				</Setter.Value>
 			</Setter>
 		</Style>
-		
-		
+
+
 		<Style x:Key="SimpleSlider" TargetType="{x:Type Slider}">
 			<Setter Property="Stylus.IsPressAndHoldEnabled" Value="true"/>
 			<Setter Property="Background" Value="Transparent"/>
@@ -487,7 +487,7 @@
 		</Style>
 		<SolidColorBrush x:Key="CheckBoxFillNormal" Color="#F4F4F4"/>
 		<SolidColorBrush x:Key="CheckBoxStroke" Color="#8E8F8F"/>
-		
+
 
 		<Style x:Key="SimpleCheckbox" TargetType="{x:Type CheckBox}">
 			<Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}"/>
@@ -653,13 +653,13 @@
 			</Setter>
 		</Style>
 	</Window.Resources>
-	
+
 	<Grid x:Name='LayoutRoot'>
 		<Grid x:Name='ContentRoot'/>
-			
+
 
 		<Grid HorizontalAlignment="Center" VerticalAlignment="Top" x:Name='Toolbar' Margin="0,4,0,0">
-			
+
 
 			<Border CornerRadius="3" BorderThickness="1">
 				<Border.BorderBrush>
@@ -676,7 +676,7 @@
 				</Border.Background>
 			</Border>
 			<Grid HorizontalAlignment="Center" Margin="8,4,8,2" VerticalAlignment="Top">
-			
+
 
 				<StackPanel Orientation='Horizontal' Width="240" x:Name='Toggles' VerticalAlignment="Top">
 
@@ -709,7 +709,7 @@
 							<Path Fill="{DynamicResource Redline}" Stretch="Fill" Stroke="{DynamicResource Redline}" StrokeLineJoin="Round" Data="M11.5,6 L11.5,2 14.5,2 11.5,0 8.5,2 11.5,2 11.5,6 z" HorizontalAlignment="Center" VerticalAlignment="Top" Width="7" Height="7" Margin="3,3,3,3"/>
 						</Grid>
 					</Button>
-					
+
 					<Button Click='StartCapture' ToolTip='Capture' x:Name='CaptureButton' Content='C' Width="25" Height="25" Style="{DynamicResource CameraButton}" Margin="0,0,5,0"/>
 
 					<!--<CheckBox x:Name='Bounds' Content='Bounds' Checked='StartBounds' Width='70' Foreground='White'/>

--- a/src/MainWindow.xaml.cs
+++ b/src/MainWindow.xaml.cs
@@ -23,11 +23,6 @@ namespace Rooler {
 
 			this.InitializeComponent();
 
-			System.Windows.IDataObject data = System.Windows.Clipboard.GetDataObject();
-
-			string [] formats = data.GetFormats();
-
-
 #if !DEBUG
 			// Makes it a royal pain to debug...
 			this.Topmost = true;

--- a/src/VirtualizedScreenShot.cs
+++ b/src/VirtualizedScreenShot.cs
@@ -25,7 +25,7 @@ namespace Rooler {
 			int countX = (int)Math.Ceiling(this.bounds.Width / (double)tileWidth);
 			int countY = (int)Math.Ceiling(this.bounds.Height / (double)tileHeight);
 
-			this.screenShots = new ScreenShot[tileWidth,tileHeight];
+			this.screenShots = new ScreenShot[countX, countY];
 		}
 
 		public int Left {
@@ -52,9 +52,9 @@ namespace Rooler {
 		}
 
 		public int GetLocalPixel(int x, int y) {
-			
+
 			int xIndex = x / this.tileWidth;
-			int yIndex = y / this.tileHeight + this.bounds.Top;
+			int yIndex = y / this.tileHeight;
 
 			ScreenShot ss = this.screenShots[xIndex, yIndex];
 			if (ss == null) {

--- a/src/VirtualizedScreenShot.cs
+++ b/src/VirtualizedScreenShot.cs
@@ -22,8 +22,8 @@ namespace Rooler {
 
 			this.bounds = ScreenShot.FullScreenBounds;
 
-			int countX = (int)Math.Ceiling(this.bounds.Width / (double)tileWidth);
-			int countY = (int)Math.Ceiling(this.bounds.Height / (double)tileHeight);
+			var countX = (int)Math.Ceiling(this.bounds.Width / (double)tileWidth) + 1;
+			var countY = (int)Math.Ceiling(this.bounds.Height / (double)tileHeight) + 1;
 
 			this.screenShots = new ScreenShot[countX, countY];
 		}


### PR DESCRIPTION
Fix crashes when having multiple displays of different sizes or positioned such that the primary display is lower than secondary displays.
Potentially reposition the overlays (main window and magnifier), so that they are visible when the "top middle" of all screens is not on an actual monitor.