### PR TITLE
Fix display scaling and positioning

### DIFF
--- a/src/App.xaml
+++ b/src/App.xaml
@@ -1,42 +1,40 @@
 ﻿<Application
-    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 		xmlns:d="http://schemas.microsoft.com/expression/blend/2008" xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" x:Class="Rooler.App"
 		StartupUri='MainWindow.xaml' mc:Ignorable="d">
-    <Application.Resources>
-         
-    	<ResourceDictionary>
-    		<ResourceDictionary.MergedDictionaries>
-    			<ResourceDictionary Source="Themes\Generic.xaml"/>
-    		</ResourceDictionary.MergedDictionaries>
-    		<SolidColorBrush x:Key="BackgroundBrush" Color="#92000000"/>
-		
-    		<Style x:Key="CloseButton" TargetType="{x:Type Button}">
-    			<Setter Property="Template">
-    				<Setter.Value>
-    					<ControlTemplate TargetType="{x:Type Button}">
-    						<Grid d:DesignWidth="12" d:DesignHeight="12">
-    							<Ellipse Fill="{TemplateBinding Background}" Stroke="{DynamicResource ButtonBackground}"/>
-    							<Path Stretch="Fill" Stroke="{TemplateBinding Foreground}" Margin="{TemplateBinding Padding}" Data="M0,0 L1,1" StrokeThickness="2"/>
-    							<Path Stretch="Fill" Stroke="{TemplateBinding Foreground}" Margin="{TemplateBinding Padding}" Data="M0,1 L1,0" StrokeThickness="2"/>
-    						</Grid>
-    					</ControlTemplate>
-    				</Setter.Value>
-    			</Setter>
-    			<Setter Property="Background" Value="#00FF0000"/>
-    			<Setter Property="Padding" Value="4,4,4,4"/>
-    			<Setter Property="Foreground" Value="#FF666666"/>
-    			<Style.Triggers>
-    				<Trigger Property="IsMouseOver" Value="True">
-    					<Setter Property="Background" Value="#90707070"/>
-    				</Trigger>
-    			</Style.Triggers>
-    		</Style>
-    		<LinearGradientBrush x:Key="ButtonBackground" EndPoint="0.5,1" StartPoint="0.5,0">
-    			<GradientStop Color="#FF656565" Offset="0"/>
-    			<GradientStop Color="DarkGray" Offset="1"/>
-    		</LinearGradientBrush>
-    	</ResourceDictionary>
-         
-    </Application.Resources>
+	<Application.Resources>
+		<ResourceDictionary>
+			<ResourceDictionary.MergedDictionaries>
+				<ResourceDictionary Source="Themes\Generic.xaml"/>
+			</ResourceDictionary.MergedDictionaries>
+			<SolidColorBrush x:Key="BackgroundBrush" Color="#92000000"/>
+
+			<Style x:Key="CloseButton" TargetType="{x:Type Button}">
+				<Setter Property="Template">
+					<Setter.Value>
+						<ControlTemplate TargetType="{x:Type Button}">
+							<Grid d:DesignWidth="12" d:DesignHeight="12">
+								<Ellipse Fill="{TemplateBinding Background}" Stroke="{DynamicResource ButtonBackground}"/>
+								<Path Stretch="Fill" Stroke="{TemplateBinding Foreground}" Margin="{TemplateBinding Padding}" Data="M0,0 L1,1" StrokeThickness="2"/>
+								<Path Stretch="Fill" Stroke="{TemplateBinding Foreground}" Margin="{TemplateBinding Padding}" Data="M0,1 L1,0" StrokeThickness="2"/>
+							</Grid>
+						</ControlTemplate>
+					</Setter.Value>
+				</Setter>
+				<Setter Property="Background" Value="#00FF0000"/>
+				<Setter Property="Padding" Value="4,4,4,4"/>
+				<Setter Property="Foreground" Value="#FF666666"/>
+				<Style.Triggers>
+					<Trigger Property="IsMouseOver" Value="True">
+						<Setter Property="Background" Value="#90707070"/>
+					</Trigger>
+				</Style.Triggers>
+			</Style>
+			<LinearGradientBrush x:Key="ButtonBackground" EndPoint="0.5,1" StartPoint="0.5,0">
+				<GradientStop Color="#FF656565" Offset="0"/>
+				<GradientStop Color="DarkGray" Offset="1"/>
+			</LinearGradientBrush>
+		</ResourceDictionary>
+	</Application.Resources>
 </Application>

--- a/src/BoundsTool.xaml
+++ b/src/BoundsTool.xaml
@@ -1,32 +1,32 @@
 ﻿<local:Tool
   xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
   xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-	xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
-	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
 	x:Class="Rooler.BoundsTool"
 	Foreground='Red'
-	xmlns:local="clr-namespace:Rooler" 
+	xmlns:local="clr-namespace:Rooler"
 	mc:Ignorable="d" d:DesignWidth="400" d:DesignHeight="400">
-	
+
 	<local:Tool.Resources>
 		<SolidColorBrush x:Key="MaskBackground" Color="#70CFCFCF"/>
 	</local:Tool.Resources>
 
 	<Grid x:Name='LayoutRoot'>
-		
+
 		<Grid x:Name="Boundary" >
 			<Grid.ColumnDefinitions>
 				<ColumnDefinition Width="*" x:Name='BoundsOffsetX'/>
 				<ColumnDefinition Width="100" x:Name='BoundsWidth'/>
 				<ColumnDefinition Width="*"/>
 			</Grid.ColumnDefinitions>
-			
+
 			<Grid.RowDefinitions>
 				<RowDefinition Height="*" x:Name='BoundsOffsetY'/>
 				<RowDefinition Height="100" x:Name='BoundsHeight'/>
 				<RowDefinition Height="*"/>
 			</Grid.RowDefinitions>
-			
+
 			<Rectangle Fill="{DynamicResource MaskBackground}" Grid.ColumnSpan="3"/>
 			<Rectangle Fill="{DynamicResource MaskBackground}" Grid.Row="2" Grid.ColumnSpan="3"/>
 			<Rectangle Fill="{DynamicResource MaskBackground}" Grid.Row="1"/>

--- a/src/BoundsTool.xaml.cs
+++ b/src/BoundsTool.xaml.cs
@@ -108,8 +108,7 @@ namespace Rooler {
 				this.BoundsWidth.Width = new GridLength(this.bounds.Width, GridUnitType.Pixel);
 				this.BoundsHeight.Height = new GridLength(this.bounds.Height, GridUnitType.Pixel);
 
-				this.Dimensions.Visibility = Visibility.Visible;
-				this.Dimensions.Text = string.Format(@"{0} x {1}", this.screenBounds.Width, this.screenBounds.Height);
+				this.DisplayScreenBounds();
 			}
 		}
 
@@ -125,11 +124,27 @@ namespace Rooler {
 			this.BoundsWidth.AnimateTo(this.bounds.Width, duration);
 			this.BoundsHeight.AnimateTo(this.bounds.Height, duration);
 
-			this.Dimensions.Visibility = Visibility.Visible;
-			this.Dimensions.Text = string.Format(@"{0} x {1}", this.screenBounds.Width, this.screenBounds.Height);
+			this.DisplayScreenBounds();
 		}
 
+		private void DisplayScreenBounds()
+		{
+			var widthWpf = this.bounds.Width;
+			var heightWpf = this.bounds.Height;
+			var widthNative = this.screenBounds.Width;
+			var heightNative = this.screenBounds.Height;
 
+			this.Dimensions.Visibility = Visibility.Visible;
+
+			if (!ScreenShot.HasDisplayScaling)
+			{
+				this.Dimensions.Text = $@"{(int) widthNative} x {(int) heightNative}";
+			}
+			else
+			{
+				this.Dimensions.Text = $@"{(int) widthWpf} x {(int) heightWpf} ({widthNative} x {heightNative})";
+			}
+		}
 
 		protected override void  OnLostMouseCapture(MouseEventArgs e) {
 			base.OnLostMouseCapture(e);

--- a/src/BoundsTool.xaml.cs
+++ b/src/BoundsTool.xaml.cs
@@ -2,8 +2,6 @@
 using System.Windows;
 using System.Windows.Input;
 using System.Windows.Media;
-using System.Windows.Media.Animation;
-using System.Diagnostics;
 
 namespace Rooler {
 	/// <summary>
@@ -27,7 +25,7 @@ namespace Rooler {
 
 			this.Dimensions.CloseClicked += delegate {
 				this.CloseService();
-			};		
+			};
 		}
 
 		protected override void OnMouseLeftButtonDown(MouseButtonEventArgs e) {
@@ -86,7 +84,7 @@ namespace Rooler {
 
 		private bool IsGrayed {
 			get {
-				return ((SolidColorBrush)this.Resources["MaskBackground"]).Color.A != 0; 
+				return ((SolidColorBrush)this.Resources["MaskBackground"]).Color.A != 0;
 			}
 			set {
 				Color currentColor = ((SolidColorBrush)this.Resources["MaskBackground"]).Color;
@@ -134,7 +132,7 @@ namespace Rooler {
 
 
 		protected override void  OnLostMouseCapture(MouseEventArgs e) {
- 			base.OnLostMouseCapture(e);
+			base.OnLostMouseCapture(e);
 
 			if (this.bounds.Width == 0 || this.bounds.Height == 0) {
 				this.CloseService();
@@ -150,20 +148,11 @@ namespace Rooler {
 			startRect.Height -= 1;
 			IntRect screenBounds = ScreenCoordinates.Collapse(startRect, this.screenshot);
 
-
 			if (!screenBounds.IsEmpty)
 				this.AnimateBounds(screenBounds);
 
 			this.BoundsRect.Visibility = Visibility.Visible;
 			this.Dimensions.CanClose = true;
-
-			//BitmapFrame frame = BitmapFrame.Create(this.screenshot.Image);
-			//PngBitmapEncoder encoder = new PngBitmapEncoder();
-			//encoder.Frames.Add(frame);
-
-			//using (FileStream fs = new FileStream(@"C:\tmp\ss.png", FileMode.Create, FileAccess.Write)) {
-			//    encoder.Save(fs);
-			//};
 		}
 	}
 }

--- a/src/Capture.xaml.cs
+++ b/src/Capture.xaml.cs
@@ -109,8 +109,7 @@ namespace Rooler {
 				this.BoundsWidth.Width = new GridLength(this.Bounds.Width, GridUnitType.Pixel);
 				this.BoundsHeight.Height = new GridLength(this.Bounds.Height, GridUnitType.Pixel);
 
-				this.Dimensions.Visibility = Visibility.Visible;
-				this.Dimensions.Text = string.Format(@"{0} x {1}", this.bounds.Width, this.bounds.Height);
+				this.DisplayBounds();
 			}
 		}
 
@@ -125,8 +124,25 @@ namespace Rooler {
 			this.BoundsWidth.AnimateTo(this.bounds.Width, duration);
 			this.BoundsHeight.AnimateTo(this.bounds.Height, duration);
 
+			this.DisplayBounds();
+		}
+
+		private void DisplayBounds()
+		{
+			var widthWpf = this.Bounds.Width;
+			var heightWpf = this.Bounds.Height;
+			var widthNative = widthWpf * ScreenShot.XRatio;
+			var heightNative = heightWpf * ScreenShot.YRatio;
+
 			this.Dimensions.Visibility = Visibility.Visible;
-			this.Dimensions.Text = string.Format(@"{0} x {1}", this.bounds.Width, this.bounds.Height);
+			if (!ScreenShot.HasDisplayScaling)
+			{
+				this.Dimensions.Text = $@"{(int) widthNative} x {(int) heightNative}";
+			}
+			else
+			{
+				this.Dimensions.Text = $@"{(int) widthWpf} x {(int) heightWpf} ({(int) widthNative} x {(int) heightNative})";
+			}
 		}
 
 		protected override void OnLostMouseCapture(MouseEventArgs e) {

--- a/src/Capture.xaml.cs
+++ b/src/Capture.xaml.cs
@@ -103,11 +103,11 @@ namespace Rooler {
 			set {
 				this.bounds = value;
 
-				this.BoundsOffsetX.Width = new GridLength(this.bounds.Left, GridUnitType.Pixel);
-				this.BoundsOffsetY.Height = new GridLength(this.bounds.Top, GridUnitType.Pixel);
+				this.BoundsOffsetX.Width = new GridLength(this.Bounds.Left, GridUnitType.Pixel);
+				this.BoundsOffsetY.Height = new GridLength(this.Bounds.Top, GridUnitType.Pixel);
 
-				this.BoundsWidth.Width = new GridLength(this.bounds.Width, GridUnitType.Pixel);
-				this.BoundsHeight.Height = new GridLength(this.bounds.Height, GridUnitType.Pixel);
+				this.BoundsWidth.Width = new GridLength(this.Bounds.Width, GridUnitType.Pixel);
+				this.BoundsHeight.Height = new GridLength(this.Bounds.Height, GridUnitType.Pixel);
 
 				this.Dimensions.Visibility = Visibility.Visible;
 				this.Dimensions.Text = string.Format(@"{0} x {1}", this.bounds.Width, this.bounds.Height);

--- a/src/DistanceTool.xaml.cs
+++ b/src/DistanceTool.xaml.cs
@@ -131,12 +131,45 @@ namespace Rooler
 			this.CenterY.Height = new GridLength(Math.Max(screenPoint.Y - bounds.Y, 0));
 			this.CenterX.Width = new GridLength(Math.Max(screenPoint.X - bounds.X, 0));
 
+
+			var widthWpf = bounds.Width;
+			var heightWpf = bounds.Height;
+			var widthNative = screenBounds.Width;
+			var heightNative = screenBounds.Height;
+
 			if (this.StretchMode == StretchMode.EastWest)
-				this.Dimensions.Text = string.Format(@"{0}", screenBounds.Width);
+			{
+				if (!ScreenShot.HasDisplayScaling)
+				{
+					this.Dimensions.Text = $@"{(int)widthNative}";
+				}
+				else
+				{
+					this.Dimensions.Text = $@"{(int)widthWpf} ({(int)widthNative})";
+				}
+			}
 			else if (this.StretchMode == StretchMode.NorthSouth)
-				this.Dimensions.Text = string.Format(@"{0}", screenBounds.Height);
+			{
+				if (!ScreenShot.HasDisplayScaling)
+				{
+					this.Dimensions.Text = $@"{(int)heightNative}";
+				}
+				else
+				{
+					this.Dimensions.Text = $@"{(int)heightWpf} ({(int)heightNative})";
+				}
+			}
 			else
-				this.Dimensions.Text = string.Format(@"{0} x {1}", screenBounds.Width, screenBounds.Height);
+			{
+				if (!ScreenShot.HasDisplayScaling)
+				{
+					this.Dimensions.Text = $@"{(int)widthNative} x {(int)heightNative}";
+				}
+				else
+				{
+					this.Dimensions.Text = $@"{(int)widthWpf} x {(int)heightWpf} ({(int)widthNative} x {(int)heightNative})";
+				}
+			}
 		}
 	}
 }

--- a/src/DistanceTool.xaml.cs
+++ b/src/DistanceTool.xaml.cs
@@ -1,37 +1,40 @@
 ﻿using System;
 using System.Windows;
 using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.IO;
 
-namespace Rooler {
-
-	public enum StretchMode {
+namespace Rooler
+{
+	public enum StretchMode
+	{
 		NorthSouth,
 		EastWest,
 		NorthSouthEastWest,
 	}
+
 	/// <summary>
 	/// Interaction logic for DistanceAdorner.xaml
 	/// </summary>
-	public partial class DistanceTool : Tool, IScreenService {
+	public partial class DistanceTool : Tool, IScreenService
+	{
 
 		private IntPoint previousPoint = new IntPoint();
 		private IScreenShot screenshot;
 
-		public DistanceTool(StretchMode stretch, IScreenServiceHost host): base(host) {
+		public DistanceTool(StretchMode stretch, IScreenServiceHost host) : base(host)
+		{
 			this.StretchMode = stretch;
 
 			this.screenshot = this.Host.CurrentScreen;
 
 			this.InitializeComponent();
 
-			if (this.StretchMode == StretchMode.EastWest) {
+			if (this.StretchMode == StretchMode.EastWest)
+			{
 				this.N.Visibility = Visibility.Collapsed;
 				this.S.Visibility = Visibility.Collapsed;
 			}
-			else if (this.StretchMode == StretchMode.NorthSouth) {
+			else if (this.StretchMode == StretchMode.NorthSouth)
+			{
 				this.E.Visibility = Visibility.Collapsed;
 				this.W.Visibility = Visibility.Collapsed;
 			}
@@ -39,46 +42,51 @@ namespace Rooler {
 			this.Cursor = Cursors.None;
 #endif
 
-			this.Dimensions.CloseClicked += delegate {
+			this.Dimensions.CloseClicked += delegate
+			{
 				this.CloseService();
 			};
 
-			this.Loaded += delegate {
+			this.Loaded += delegate
+			{
 				this.Update();
 			};
 		}
-		
+
 
 		public StretchMode StretchMode { get; set; }
 
-		protected override void OnMouseMove(MouseEventArgs e) {
+		protected override void OnMouseMove(MouseEventArgs e)
+		{
 			base.OnMouseMove(e);
 
 			if (!this.IsFrozen)
 				this.Update(false);
 		}
 
-		public override void Update() {
+		public override void Update()
+		{
 			this.Update(true);
 		}
 
-		private void Update(bool force) {
+		private void Update(bool force)
+		{
 			IntPoint mousePt = NativeMethods.GetCursorPos();
 
-			if (Keyboard.IsKeyDown(Key.Space)) {
-			      }
-
-			if (force || mousePt != this.previousPoint) {
+			if (force || mousePt != this.previousPoint)
+			{
 				this.previousPoint = mousePt;
 
 				IntRect rect = ScreenCoordinates.ExpandPoint(mousePt, this.screenshot);
-				if (!rect.IsEmpty) {
+				if (!rect.IsEmpty)
+				{
 					this.UpdateBounds(rect, mousePt);
 				}
 			}
 		}
 
-		protected override void OnMouseLeftButtonDown(MouseButtonEventArgs e) {
+		protected override void OnMouseLeftButtonDown(MouseButtonEventArgs e)
+		{
 			base.OnMouseLeftButtonDown(e);
 
 			if (!this.Host.PreserveAnnotations)
@@ -87,8 +95,10 @@ namespace Rooler {
 				this.Freeze();
 		}
 
-		protected override void OnKeyDown(KeyEventArgs e) {
-			switch (e.Key) {
+		protected override void OnKeyDown(KeyEventArgs e)
+		{
+			switch (e.Key)
+			{
 				case Key.Enter:
 					this.Freeze();
 					e.Handled = true;
@@ -97,7 +107,8 @@ namespace Rooler {
 			base.OnKeyDown(e);
 		}
 
-		protected override void Freeze() {
+		protected override void Freeze()
+		{
 			base.Freeze();
 
 			this.Background = null;
@@ -105,7 +116,8 @@ namespace Rooler {
 			this.Dimensions.CanClose = true;
 		}
 
-		protected void UpdateBounds(IntRect screenBounds, IntPoint point) {
+		protected void UpdateBounds(IntRect screenBounds, IntPoint point)
+		{
 
 			Rect bounds = NativeMethods.ScreenToClient(this, screenBounds);
 			Point screenPoint = NativeMethods.ScreenToClient(this, point);
@@ -113,7 +125,7 @@ namespace Rooler {
 			this.Bounds.Width = bounds.Width;
 			this.Bounds.Height = bounds.Height;
 
-			
+
 			this.Bounds.Margin = new Thickness(bounds.Left, bounds.Top, 0, 0);
 
 			this.CenterY.Height = new GridLength(Math.Max(screenPoint.Y - bounds.Y, 0));
@@ -126,27 +138,5 @@ namespace Rooler {
 			else
 				this.Dimensions.Text = string.Format(@"{0} x {1}", screenBounds.Width, screenBounds.Height);
 		}
-
-		//protected override void OnKeyUp(KeyEventArgs e) {
-		//    base.OnKeyUp(e);
-
-		//    if (e.Key == Key.D) {
-		//        VirtualizedScreenShot vs = this.screenshot as VirtualizedScreenShot;
-		//        if (vs != null) {
-		//            Point mousePt = NativeMethods.GetCursorPos();
-		//            ScreenShot currentTile = vs.GetTile((int)mousePt.X, (int)mousePt.Y);
-
-		//            if (currentTile != null) {
-		//                BitmapFrame frame = BitmapFrame.Create(currentTile.Image);
-		//                PngBitmapEncoder encoder = new PngBitmapEncoder();
-		//                encoder.Frames.Add(frame);
-
-		//                using (FileStream fs = new FileStream(@"C:\tmp\ss.png", FileMode.Create, FileAccess.Write)) {
-		//                    encoder.Save(fs);
-		//                };
-		//            }
-		//        }
-		//    }
-		//}
 	}
 }

--- a/src/Dragger.cs
+++ b/src/Dragger.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using System.Windows;
 using System.Windows.Forms;
 using System.Windows.Input;
@@ -19,29 +20,17 @@ namespace Rooler
 
 			this.target.Loaded += (sender, args) =>
 			{
-				// Calculate the offset:
-				// With multiple displays, depending their relative positioning,
-				// simply centering the target at the top may be outside the visual area.
+				// Calculate the initial offset:
+				// in the top center of the current screen
 				var currentScreen = Screen.FromPoint(System.Windows.Forms.Cursor.Position);
 				var fullScreen = ScreenShot.FullScreenBounds;
 
-				var centerOfAllScreensX = fullScreen.Width/2.0;
-				var centerOfAllScreensY = (double)fullScreen.Top;
+				var xOffset = currentScreen.Bounds.Left + currentScreen.Bounds.Width / 2.0;
+				var yOffset = (double)currentScreen.Bounds.Top;
 
-				var centerOfCurrentScreenX = currentScreen.Bounds.Left + currentScreen.Bounds.Width/2;
-				var centerOfCurrentScreenY = currentScreen.Bounds.Top;
-
-				// Calculate the offset (difference between the top-center of all screens and that of the current screen.
-				var xOffset = centerOfCurrentScreenX - centerOfAllScreensX;
-				var yOffset = centerOfCurrentScreenY - centerOfAllScreensY;
-
-				// Transform the WinForms pixels (system dpi) to WPF pixels (based on virtual 96dpi).
-				var source = PresentationSource.FromVisual(target);
-				if (source?.CompositionTarget != null)
-				{
-					xOffset = xOffset / source.CompositionTarget.TransformToDevice.M11;
-					yOffset = yOffset / source.CompositionTarget.TransformToDevice.M22;
-				}
+				// Transform the WinForms pixels (system dpi) to WPF pixels (based on virtual 96dpi)
+				xOffset = xOffset / ScreenShot.XRatio;
+				yOffset = yOffset / ScreenShot.YRatio;
 
 				this.offset.X = xOffset;
 				this.offset.Y = yOffset;

--- a/src/Dragger.cs
+++ b/src/Dragger.cs
@@ -25,8 +25,8 @@ namespace Rooler
 				var currentScreen = Screen.FromPoint(System.Windows.Forms.Cursor.Position);
 				var fullScreen = ScreenShot.FullScreenBounds;
 
-				var xOffset = currentScreen.Bounds.Left + currentScreen.Bounds.Width / 2.0;
-				var yOffset = (double)currentScreen.Bounds.Top;
+				var xOffset = Math.Abs(fullScreen.Left) + Math.Abs(currentScreen.Bounds.Left) + currentScreen.Bounds.Width / 2.0;
+				var yOffset = (double)Math.Abs(fullScreen.Top) + Math.Abs(currentScreen.Bounds.Top);
 
 				// Transform the WinForms pixels (system dpi) to WPF pixels (based on virtual 96dpi)
 				xOffset = xOffset / ScreenShot.XRatio;

--- a/src/Dragger.cs
+++ b/src/Dragger.cs
@@ -4,14 +4,17 @@ using System.Windows.Forms;
 using System.Windows.Input;
 using System.Windows.Media;
 
-namespace Rooler {
-	public class Dragger {
+namespace Rooler
+{
+	public class Dragger
+	{
 
 		private FrameworkElement target;
 		private TranslateTransform offset = new TranslateTransform();
 		private Point lastMousePt;
 
-		public Dragger(FrameworkElement target) {
+		public Dragger(FrameworkElement target)
+		{
 			this.target = target;
 
 			this.target.Loaded += (sender, args) =>
@@ -49,32 +52,33 @@ namespace Rooler {
 			this.target.MouseLeftButtonDown += this.HandleMouseDown;
 			this.target.MouseLeftButtonUp += this.HandleMouseUp;
 			this.target.MouseMove += this.HandleMouseMove;
-			this.target.LostMouseCapture += this.HandleLostCapture;
 		}
 
-		private void HandleMouseDown(object sender, MouseButtonEventArgs e) {
+		private void HandleMouseDown(object sender, MouseButtonEventArgs e)
+		{
 			this.lastMousePt = e.GetPosition(this.target);
 
-			if (this.target.CaptureMouse()) {
+			if (this.target.CaptureMouse())
+			{
 				this.lastMousePt = e.GetPosition(this.target);
 				e.Handled = true;
 			}
 		}
 
-		private void HandleMouseUp(object sender, MouseButtonEventArgs e) {
+		private void HandleMouseUp(object sender, MouseButtonEventArgs e)
+		{
 			this.target.ReleaseMouseCapture();
 		}
 
-		private void HandleMouseMove(object sender, System.Windows.Input.MouseEventArgs e) {
-			if (this.target.IsMouseCaptured) {
+		private void HandleMouseMove(object sender, System.Windows.Input.MouseEventArgs e)
+		{
+			if (this.target.IsMouseCaptured)
+			{
 				Point point = e.GetPosition(this.target);
 
 				this.offset.X += point.X - this.lastMousePt.X;
 				this.offset.Y += point.Y - this.lastMousePt.Y;
 			}
-		}
-
-		private void HandleLostCapture(object sender, EventArgs e) {
 		}
 	}
 }

--- a/src/Magnifier.xaml
+++ b/src/Magnifier.xaml
@@ -26,9 +26,6 @@
 			<RowDefinition Height="Auto"/>
 		</Grid.RowDefinitions>
 		<Border Background="{DynamicResource BackgroundBrush}" Grid.RowSpan="2">
-			<Border.Effect>
-				<DropShadowEffect />
-			</Border.Effect>
 		</Border>
 		<Grid Margin="4,4,4,4" Width="300" Height="300">
 			<Grid.RowDefinitions>

--- a/src/Magnifier.xaml
+++ b/src/Magnifier.xaml
@@ -1,48 +1,13 @@
 ﻿<local:Tool
 	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-	xmlns:local='clr-namespace:Rooler' xmlns:d="http://schemas.microsoft.com/expression/blend/2008" xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-	mc:Ignorable="d" xmlns:Microsoft_Windows_Themes="clr-namespace:Microsoft.Windows.Themes;assembly=PresentationFramework.Aero" x:Class="Rooler.Magnifier" FontFamily="Consolas"
+	xmlns:local='clr-namespace:Rooler'
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	mc:Ignorable="d"
+	x:Class="Rooler.Magnifier"
+	FontFamily="Consolas"
 	>
-	<local:Tool.Resources>
-		<Style x:Key="ButtonFocusVisual">
-			<Setter Property="Control.Template">
-				<Setter.Value>
-					<ControlTemplate>
-						<Rectangle Stroke="Black" StrokeDashArray="1 2" StrokeThickness="1" Margin="2" SnapsToDevicePixels="true"/>
-					</ControlTemplate>
-				</Setter.Value>
-			</Setter>
-		</Style>
-		<LinearGradientBrush x:Key="ButtonNormalBackground" EndPoint="0,1" StartPoint="0,0">
-			<GradientStop Color="#F3F3F3" Offset="0"/>
-			<GradientStop Color="#EBEBEB" Offset="0.5"/>
-			<GradientStop Color="#DDDDDD" Offset="0.5"/>
-			<GradientStop Color="#CDCDCD" Offset="1"/>
-		</LinearGradientBrush>
-		<SolidColorBrush x:Key="ButtonNormalBorder" Color="#FF707070"/>
-		<Style x:Key="CloseButton" TargetType="{x:Type Button}">
-			<Setter Property="Template">
-				<Setter.Value>
-					<ControlTemplate TargetType="{x:Type Button}">
-						<Grid d:DesignWidth="12" d:DesignHeight="12">
-							<Ellipse Fill="{TemplateBinding Background}" Stroke="{TemplateBinding Foreground}"/>
-							<Path Stretch="Fill" Stroke="{TemplateBinding Foreground}" Margin="{TemplateBinding Padding}" Data="M0,0 L1,1" StrokeThickness="2"/>
-							<Path Stretch="Fill" Stroke="{TemplateBinding Foreground}" Margin="{TemplateBinding Padding}" Data="M0,1 L1,0" StrokeThickness="2"/>
-						</Grid>
-					</ControlTemplate>
-				</Setter.Value>
-			</Setter>
-			<Setter Property="Background" Value="#00FF0000"/>
-			<Setter Property="Padding" Value="4,4,4,4"/>
-			<Setter Property="Foreground" Value="#FF666666"/>
-			<Style.Triggers>
-				<Trigger Property="IsMouseOver" Value="True">
-					<Setter Property="Background" Value="#90707070"/>
-				</Trigger>
-			</Style.Triggers>
-		</Style>
-	</local:Tool.Resources>
 	<Grid HorizontalAlignment="Center" VerticalAlignment="Top" RenderTransformOrigin="0.5,0.5">
 		<Grid.RenderTransform>
 			<TransformGroup>
@@ -66,7 +31,6 @@
 			</Border.Effect>
 		</Border>
 		<Grid Margin="4,4,4,4" Width="300" Height="300">
-
 			<Grid.RowDefinitions>
 				<RowDefinition Height="100" x:Name='CenterY'/>
 				<RowDefinition Height="*"/>
@@ -86,7 +50,7 @@
 				<TextBlock x:Name="MouseX" Text="X:100" Foreground="#FFFFFFFF" />
 				<TextBlock x:Name="MouseY" Text="Y:100" Foreground="#FFFFFFFF" Margin="8,0,0,0" />
 			</StackPanel>
-			
+
 			<TextBlock x:Name="PixelColor" DockPanel.Dock="Right" Text="#FF000000" Foreground="#FFFFFFFF" />
 			<Rectangle x:Name="ColorSwatch" Fill="Red" Height="10" Margin="4,0"/>
 		</DockPanel>

--- a/src/Magnifier.xaml
+++ b/src/Magnifier.xaml
@@ -8,7 +8,7 @@
 	x:Class="Rooler.Magnifier"
 	FontFamily="Consolas"
 	>
-	<Grid HorizontalAlignment="Center" VerticalAlignment="Top" RenderTransformOrigin="0.5,0.5">
+	<Grid HorizontalAlignment="Left" VerticalAlignment="Top" RenderTransformOrigin="0.5,0.5">
 		<Grid.RenderTransform>
 			<TransformGroup>
 				<ScaleTransform/>

--- a/src/Magnifier.xaml.cs
+++ b/src/Magnifier.xaml.cs
@@ -5,10 +5,10 @@ using System.Windows.Media;
 using System.Windows.Media.Imaging;
 using System.Windows.Threading;
 
-namespace Rooler {
-	
-	public partial class Magnifier : Tool {
-
+namespace Rooler
+{
+	public partial class Magnifier : Tool
+	{
 		private bool isPaused = false;
 
 		public static RoutedCommand CopyCommand = new RoutedCommand("Copy", typeof(Magnifier));
@@ -18,9 +18,8 @@ namespace Rooler {
 		private IntPoint lastMousePoint = new IntPoint();
 		private IntPoint basePoint = new IntPoint();
 
-		
-
-		public Magnifier(IScreenServiceHost host): base(host) {
+		public Magnifier(IScreenServiceHost host) : base(host)
+		{
 			this.InitializeComponent();
 
 			new Dragger(this);
@@ -29,13 +28,15 @@ namespace Rooler {
 
 			this.Scale = 8;
 
-			DispatcherTimer timer = new DispatcherTimer() {
+			DispatcherTimer timer = new DispatcherTimer()
+			{
 				Interval = TimeSpan.FromSeconds(.03),
 				IsEnabled = true,
 			};
 			timer.Tick += this.HandleTick;
 
-			this.Loaded += delegate {
+			this.Loaded += delegate
+			{
 				this.Focus();
 			};
 
@@ -45,23 +46,26 @@ namespace Rooler {
 			this.InputBindings.Add(new InputBinding(Magnifier.SetBasePointCommand, new KeyGesture(Key.Enter)));
 			this.CommandBindings.Add(new CommandBinding(Magnifier.SetBasePointCommand, this.SetBasePointExecuted));
 		}
-		
-		private void CloseMagnifier(object sender, EventArgs e) {
+
+		private void CloseMagnifier(object sender, EventArgs e)
+		{
 			this.CloseService();
 		}
 
-
-		private void CopyCommandExecuted(object sender, ExecutedRoutedEventArgs e) {
+		private void CopyCommandExecuted(object sender, ExecutedRoutedEventArgs e)
+		{
 			Clipboard.SetText(this.PixelColor.Text);
 		}
 
-		private void SetBasePointExecuted(object sender, ExecutedRoutedEventArgs e) {
+		private void SetBasePointExecuted(object sender, ExecutedRoutedEventArgs e)
+		{
 			this.basePoint = NativeMethods.GetCursorPos();
 		}
 
 		public double Scale { get; set; }
 
-		protected override void OnMouseWheel(MouseWheelEventArgs e) {
+		protected override void OnMouseWheel(MouseWheelEventArgs e)
+		{
 
 			if (e.Delta > 0)
 				this.Scale += 1;
@@ -72,11 +76,12 @@ namespace Rooler {
 			base.OnMouseWheel(e);
 		}
 
-		private void HandleTick(object sender, EventArgs e) {
-
+		private void HandleTick(object sender, EventArgs e)
+		{
 			IntPoint mousePoint = NativeMethods.GetCursorPos();
 
-			if (mousePoint == this.lastMousePoint && DateTime.Now - this.lastCapture < TimeSpan.FromSeconds(.2)) {
+			if (mousePoint == this.lastMousePoint && DateTime.Now - this.lastCapture < TimeSpan.FromSeconds(.2))
+			{
 				return;
 			}
 
@@ -93,7 +98,6 @@ namespace Rooler {
 			double width = this.Image.ActualWidth / this.Scale;
 			double height = this.Image.ActualHeight / this.Scale;
 
-			
 
 			double left = (mousePoint.X - width / 2).Clamp(ScreenShot.FullScreenBounds.Left, ScreenShot.FullScreenBounds.Width - width);
 			double top = (mousePoint.Y - height / 2).Clamp(ScreenShot.FullScreenBounds.Top, ScreenShot.FullScreenBounds.Height - height);
@@ -112,7 +116,7 @@ namespace Rooler {
 			else
 				this.CenterY.Height = new GridLength(this.Image.ActualHeight / 2 + 8);
 
-			
+
 
 			IntRect rect = new IntRect((int)left, (int)top, (int)width, (int)height);
 
@@ -139,18 +143,6 @@ namespace Rooler {
 			this.ColorSwatch.Fill = brush;
 
 			this.PixelColor.Text = string.Format(@"#{0:X8}", centerPixel);
-		}
-
-		protected override void OnMouseEnter(MouseEventArgs e) {
-			base.OnMouseEnter(e);
-
-			//this.isPaused = true;
-		}
-
-		protected override void OnMouseLeave(MouseEventArgs e) {
-			base.OnMouseLeave(e);
-
-			//this.isPaused = false;
 		}
 	}
 }

--- a/src/MainWindow.xaml
+++ b/src/MainWindow.xaml
@@ -658,7 +658,7 @@
 		<Grid x:Name='ContentRoot'/>
 
 
-		<Grid HorizontalAlignment="Center" VerticalAlignment="Top" x:Name='Toolbar' Margin="0,4,0,0">
+		<Grid HorizontalAlignment="Left" VerticalAlignment="Top" x:Name='Toolbar' Margin="0,4,0,0">
 
 
 			<Border CornerRadius="3" BorderThickness="1">

--- a/src/MainWindow.xaml.cs
+++ b/src/MainWindow.xaml.cs
@@ -6,11 +6,13 @@ using System.Windows;
 using System.Windows.Input;
 using System.Windows.Controls.Primitives;
 
-namespace Rooler {
+namespace Rooler
+{
 	/// <summary>
 	/// Interaction logic for Window1.xaml
 	/// </summary>
-	public partial class MainWindow : Window, INotifyPropertyChanged, IScreenServiceHost {
+	public partial class MainWindow : Window, INotifyPropertyChanged, IScreenServiceHost
+	{
 
 
 		private IScreenService currentService = null;
@@ -19,7 +21,8 @@ namespace Rooler {
 
 		private Magnifier magnifier;
 
-		public MainWindow() {
+		public MainWindow()
+		{
 
 			this.InitializeComponent();
 
@@ -34,7 +37,8 @@ namespace Rooler {
 
 			this.ToleranceSlider.Value = ScreenCoordinates.ColorTolerance;
 
-			this.ToleranceSlider.ValueChanged += delegate {
+			this.ToleranceSlider.ValueChanged += delegate
+			{
 				ScreenCoordinates.ColorTolerance = this.ToleranceSlider.Value;
 			};
 
@@ -48,15 +52,18 @@ namespace Rooler {
 		}
 
 		private bool preserveAnnotations;
-		public bool PreserveAnnotations {
+		public bool PreserveAnnotations
+		{
 			get { return this.preserveAnnotations; }
-			set {
+			set
+			{
 				this.preserveAnnotations = value;
 				this.OnPropertyChanged("PreserveAnnotations");
 			}
 		}
 
-		protected override void OnDeactivated(EventArgs e) {
+		protected override void OnDeactivated(EventArgs e)
+		{
 
 			this.CurrentService = null;
 
@@ -64,25 +71,30 @@ namespace Rooler {
 			base.OnDeactivated(e);
 		}
 
-		private void StartBounds(object sender, EventArgs e) {
+		private void StartBounds(object sender, EventArgs e)
+		{
 			this.CurrentService = new BoundsTool(this);
 		}
 
-		private void StartStretch(object sender, EventArgs e) {
+		private void StartStretch(object sender, EventArgs e)
+		{
 			this.CurrentService = new DistanceTool(StretchMode.NorthSouthEastWest, this);
 		}
 
-		private void StartStretchNS(object sender, EventArgs e) {
+		private void StartStretchNS(object sender, EventArgs e)
+		{
 			this.CurrentService = new DistanceTool(StretchMode.NorthSouth, this);
 		}
 
-		private void StartStretchEW(object sender, EventArgs e) {
+		private void StartStretchEW(object sender, EventArgs e)
+		{
 			this.CurrentService = new DistanceTool(StretchMode.EastWest, this);
 		}
 
-		private void StartMagnify(object sender, EventArgs e) {
-
-			if (this.magnifier != null) {
+		private void StartMagnify(object sender, EventArgs e)
+		{
+			if (this.magnifier != null)
+			{
 				this.magnifier.CloseService();
 				this.magnifier = null;
 			}
@@ -90,7 +102,8 @@ namespace Rooler {
 			this.magnifier = new Magnifier(this);
 			this.ContentRoot.Children.Add(this.magnifier.Visual);
 
-			this.magnifier.ServiceClosed += delegate {
+			this.magnifier.ServiceClosed += delegate
+			{
 				this.Magnify.IsChecked = false;
 				if (this.magnifier != null)
 					this.ContentRoot.Children.Remove(this.magnifier.Visual);
@@ -98,20 +111,26 @@ namespace Rooler {
 			};
 		}
 
-		private void StopMagnify(object sender, EventArgs e) {
+		private void StopMagnify(object sender, EventArgs e)
+		{
 			if (this.magnifier != null)
 				this.magnifier.CloseService();
 		}
 
-		private void StartCapture(object sender, EventArgs e) {
+		private void StartCapture(object sender, EventArgs e)
+		{
 			this.CurrentService = new Capture(this);
 		}
 
-		public IScreenService CurrentService {
+		public IScreenService CurrentService
+		{
 			get { return this.currentService; }
-			set {
-				if (this.currentService != null) {
-					if (!this.PreserveAnnotations && !this.currentService.IsFrozen) {
+			set
+			{
+				if (this.currentService != null)
+				{
+					if (!this.PreserveAnnotations && !this.currentService.IsFrozen)
+					{
 						this.currentService.CloseService();
 						Debug.Assert(this.currentService == null);
 					}
@@ -119,7 +138,8 @@ namespace Rooler {
 
 				this.currentService = value;
 
-				if (this.currentService != null) {
+				if (this.currentService != null)
+				{
 					this.currentServices.Add(this.currentService);
 					this.ContentRoot.Children.Add(this.currentService.Visual);
 					this.currentService.ServiceClosed += this.ServiceClosed;
@@ -128,17 +148,20 @@ namespace Rooler {
 		}
 
 		private IScreenShot lastScreenshot;
-		public IScreenShot CurrentScreen {
-			get {
-				if (this.currentServices.Count == 0) {
+		public IScreenShot CurrentScreen
+		{
+			get
+			{
+				if (this.currentServices.Count == 0)
+				{
 					this.lastScreenshot = new VirtualizedScreenShot();
-					//this.lastScreenshot = new ScreenShot();
 				}
 				return this.lastScreenshot;
 			}
 		}
 
-		private void ServiceClosed(object sender, EventArgs e) {
+		private void ServiceClosed(object sender, EventArgs e)
+		{
 
 			IScreenService service = (IScreenService)sender;
 
@@ -151,34 +174,41 @@ namespace Rooler {
 			if (service == this.currentService)
 				this.currentService = null;
 
-			foreach (UIElement child in this.Toggles.Children) {
+			foreach (UIElement child in this.Toggles.Children)
+			{
 				ToggleButton tb = child as ToggleButton;
 				if (tb != null)
 					tb.IsChecked = false;
 			}
 		}
 
-		private void Close(object sender, EventArgs e) {
+		private void Close(object sender, EventArgs e)
+		{
 			this.Close();
 		}
 
-		protected override void OnMouseLeftButtonDown(MouseButtonEventArgs e) {
+		protected override void OnMouseLeftButtonDown(MouseButtonEventArgs e)
+		{
 			base.OnMouseLeftButtonDown(e);
 
 			this.DragMove();
 		}
 
-		protected override void OnKeyDown(System.Windows.Input.KeyEventArgs e) {
+		protected override void OnKeyDown(System.Windows.Input.KeyEventArgs e)
+		{
 			base.OnKeyDown(e);
 
-			if (e.Key == Key.Escape) {
+			if (e.Key == Key.Escape)
+			{
 				this.CloseAllServices();
 			}
 		}
 
-		private void CloseAllServices() {
+		private void CloseAllServices()
+		{
 			List<IScreenService> currentServices = new List<IScreenService>(this.currentServices);
-			foreach (IScreenService service in currentServices) {
+			foreach (IScreenService service in currentServices)
+			{
 				service.CloseService();
 			}
 
@@ -189,7 +219,8 @@ namespace Rooler {
 			Debug.Assert(this.currentServices.Count == 0);
 		}
 
-		protected override void OnMouseWheel(MouseWheelEventArgs e) {
+		protected override void OnMouseWheel(MouseWheelEventArgs e)
+		{
 			base.OnMouseWheel(e);
 
 			this.Preferences.IsExpanded = true;
@@ -200,7 +231,8 @@ namespace Rooler {
 		}
 
 		public event PropertyChangedEventHandler PropertyChanged;
-		protected void OnPropertyChanged(string propertyName) {
+		protected void OnPropertyChanged(string propertyName)
+		{
 			Debug.Assert(this.GetType().GetProperty(propertyName) != null);
 			if (this.PropertyChanged != null)
 				this.PropertyChanged(this, new PropertyChangedEventArgs(propertyName));

--- a/src/MainWindow.xaml.cs
+++ b/src/MainWindow.xaml.cs
@@ -44,7 +44,8 @@ namespace Rooler
 
 			this.DataContext = this;
 
-			IntRect screenBounds = ScreenShot.FullScreenBounds;
+			var screenBounds = ScreenShot.FullScreenBoundsWpf;
+
 			this.Top = screenBounds.Top;
 			this.Left = screenBounds.Left;
 			this.Width = screenBounds.Width;

--- a/src/ScreenService.cs
+++ b/src/ScreenService.cs
@@ -1,9 +1,10 @@
 ﻿using System;
 using System.Windows;
 
-namespace Rooler {
-	public interface IScreenService {
-
+namespace Rooler
+{
+	public interface IScreenService
+	{
 		FrameworkElement Visual { get; }
 
 		void CloseService();
@@ -14,7 +15,8 @@ namespace Rooler {
 		bool IsFrozen { get; }
 	}
 
-	public interface IScreenServiceHost {
+	public interface IScreenServiceHost
+	{
 		bool PreserveAnnotations { get; }
 		IScreenShot CurrentScreen { get; }
 	}

--- a/src/ScreenShot.cs
+++ b/src/ScreenShot.cs
@@ -5,9 +5,10 @@ using System.Windows.Interop;
 using System.Windows.Media.Imaging;
 using System.Diagnostics;
 
-namespace Rooler {
-
-	public interface IScreenShot {
+namespace Rooler
+{
+	public interface IScreenShot
+	{
 
 		int Left { get; }
 		int Top { get; }
@@ -18,39 +19,46 @@ namespace Rooler {
 		int GetScreenPixel(int x, int y);
 	}
 
-
-	public class ScreenShot: IScreenShot {
+	public class ScreenShot : IScreenShot
+	{
 		private BitmapSource bitmap;
 		private int[] pixels;
 		private IntRect bounds;
 
-		public ScreenShot() {
+		public ScreenShot()
+		{
 			this.Capture(ScreenShot.FullScreenBounds);
 		}
 
-		public ScreenShot(IntRect screenBounds): this(screenBounds, true) {
+		public ScreenShot(IntRect screenBounds) : this(screenBounds, true)
+		{
 		}
 
-		public ScreenShot(IntRect screenBounds, bool keepBitmap) {
+		public ScreenShot(IntRect screenBounds, bool keepBitmap)
+		{
 			this.Capture(screenBounds);
 
 			if (!keepBitmap)
 				this.bitmap = null;
 		}
 
-		public ScreenShot(BitmapSource bitmap) {
+		public ScreenShot(BitmapSource bitmap)
+		{
 			this.Init(bitmap);
 		}
 
-		private void Capture(IntRect bounds) {
-
+		private void Capture(IntRect bounds)
+		{
 			this.bounds = bounds;
 
 			BitmapSource bitmap = null;
 
-			using (NativeMethods.DC hdcScreen = NativeMethods.CreateDC("Display", null, null, IntPtr.Zero)) {
-				using (NativeMethods.DC hdcDest = hdcScreen.CreateCompatibleDC()) {
-					using (NativeMethods.GdiObject hBitmap = hdcScreen.CreateCompatibleBitmap(bounds.Width, bounds.Height)) {
+			using (NativeMethods.DC hdcScreen = NativeMethods.CreateDC("Display", null, null, IntPtr.Zero))
+			{
+				using (NativeMethods.DC hdcDest = hdcScreen.CreateCompatibleDC())
+				{
+					using (NativeMethods.GdiObject hBitmap = hdcScreen.CreateCompatibleBitmap(bounds.Width, bounds.Height))
+					{
 						NativeMethods.GdiObject oldBitmap = hdcDest.SelectObject(hBitmap);
 						hdcDest.BitBlt(0, 0, bounds.Width, bounds.Height, hdcScreen, bounds.Left, bounds.Top, 0xcc0020);
 
@@ -61,95 +69,80 @@ namespace Rooler {
 				}
 			}
 
-			//IntPtr hdcScreen = NativeMethods.CreateDC("Display", null, null, IntPtr.Zero);
-			//if (hdcScreen != IntPtr.Zero) {
-			//    IntPtr hdcDest = NativeMethods.CreateCompatibleDC(hdcScreen);
-			//    if (hdcDest != IntPtr.Zero) {
-			//        IntPtr hBitmap = NativeMethods.CreateCompatibleBitmap(hdcScreen, bounds.Width, bounds.Height);
-			//        if (hBitmap != IntPtr.Zero) {
-			//            IntPtr oldBitmap = NativeMethods.SelectObject(hdcDest, hBitmap);
-			//            NativeMethods.BitBlt(hdcDest, 0, 0, bounds.Width, bounds.Height, hdcScreen, bounds.X, bounds.Y, 0xcc0020);
-
-
-			//            bitmap = Imaging.CreateBitmapSourceFromHBitmap(hBitmap, IntPtr.Zero, new Int32Rect(0, 0, bounds.Width, bounds.Height), null);
-			//            NativeMethods.SelectObject(hdcDest, oldBitmap);
-			//            NativeMethods.DeleteObject(hBitmap);
-			//        }
-			//        NativeMethods.DeleteDC(hdcDest);
-			//    }
-			//    NativeMethods.DeleteDC(hdcScreen);
-			//}
-
-			if (bitmap != null) {
+			if (bitmap != null)
+			{
 				this.Init(bitmap);
 			}
 		}
 
-		private static IntRect fullScreenBounds = new IntRect();
-		public static IntRect FullScreenBounds {
-			get {
-				if (fullScreenBounds.IsEmpty) {
-					IntRect fullBounds = new IntRect();
-					foreach (Screen screen in Screen.AllScreens) {
-						fullBounds.Union(new IntRect(screen.Bounds.Left, screen.Bounds.Top, screen.Bounds.Width, screen.Bounds.Height));
-					}
-					fullScreenBounds = fullBounds;
-				}
+		private static Lazy<IntRect> _fullScreenBounds = new Lazy<IntRect>(() =>
+		{
+			var fullBounds = new IntRect();
+			foreach (Screen screen in Screen.AllScreens)
+			{
+				fullBounds.Union(new IntRect(screen.Bounds.Left, screen.Bounds.Top, screen.Bounds.Width, screen.Bounds.Height));
+			}
 
-				return fullScreenBounds;
+
+			return fullBounds;
+		});
+
+		/// <summary>
+		/// Gets the bounds of across all screens, in native pixels.
+		/// </summary>
+		public static IntRect FullScreenBounds
+		{
+			get
+			{
+				return _fullScreenBounds.Value;
 			}
 		}
 
-		private void Init(BitmapSource bitmap) {
+		private void Init(BitmapSource bitmap)
+		{
 			this.bitmap = bitmap;
 			this.pixels = new int[this.bitmap.PixelWidth * this.bitmap.PixelHeight];
 			this.bitmap.CopyPixels(pixels, this.bitmap.PixelWidth * 4, 0);
 		}
 
-		public int Left { 
-			get { return this.bounds.Left; } 
+		public int Left
+		{
+			get { return this.bounds.Left; }
 		}
 
-		public int Top {
+		public int Top
+		{
 			get { return this.bounds.Top; }
 		}
 
-		public int Right {
+		public int Right
+		{
 			get { return this.bounds.Right; }
 		}
 
-		public int Bottom {
+		public int Bottom
+		{
 			get { return this.bounds.Bottom; }
 		}
 
-		//public int this[int x, int y] {
-		//    get {
-		//        return this.GetPixel(x, y);
-		//    }
-		//}
-
-		public int GetScreenPixel(int x, int y) {
+		public int GetScreenPixel(int x, int y)
+		{
 			x -= this.bounds.Left;
 			y -= this.bounds.Top;
 
 			return this.GetLocalPixel(x, y);
 		}
 
-		public int GetLocalPixel(int x, int y) {
-
-			
-
+		public int GetLocalPixel(int x, int y)
+		{
 			int newX = x.Clamp(0, this.bounds.Width - 1);
 			int newY = y.Clamp(0, this.bounds.Height - 1);
-
-			//Debug.Assert(newX == x && newY == y);
-
-
 
 			return this.pixels[newY * this.bounds.Width + newX];
 		}
 
-		public BitmapSource Image {
+		public BitmapSource Image
+		{
 			get { return this.bitmap; }
 		}
 	}

--- a/src/ScreenShot.cs
+++ b/src/ScreenShot.cs
@@ -98,6 +98,26 @@ namespace Rooler
 			}
 		}
 
+		/// <summary>
+		/// Gets the bounds of across all screens, in WPF pixels.
+		/// These consider the display scaling of the primary screen.
+		/// </summary>
+		public static IntRect FullScreenBoundsWpf
+		{
+			get
+			{
+				var unscaled = FullScreenBounds;
+				return new IntRect((int)(unscaled.Left / XRatio), (int)(unscaled.Top / YRatio), (int)(unscaled.Width / XRatio),
+					(int)(unscaled.Height / YRatio));
+
+			}
+		}
+
+		public static double XRatio = Screen.PrimaryScreen.Bounds.Width / SystemParameters.PrimaryScreenWidth;
+		public static double YRatio = Screen.PrimaryScreen.Bounds.Height / SystemParameters.PrimaryScreenHeight;
+
+		public static bool HasDisplayScaling = XRatio != 1 || YRatio != 1;
+
 		private void Init(BitmapSource bitmap)
 		{
 			this.bitmap = bitmap;

--- a/src/Themes/Generic.xaml
+++ b/src/Themes/Generic.xaml
@@ -1,10 +1,8 @@
 ﻿<ResourceDictionary
-    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:local="clr-namespace:Rooler" xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:local="clr-namespace:Rooler" xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
 	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" mc:Ignorable="d" >
-
-
 	<Style TargetType="{x:Type local:Dimensions}">
 		<Setter Property='Background' Value='#92000000'/>
 		<Setter Property='Foreground' Value='#FFFFFFFF'/>
@@ -23,7 +21,7 @@
 								<Condition Property='CanClose' Value='True'/>
 								<Condition Property='IsMouseOver' Value='True'/>
 							</MultiTrigger.Conditions>
-							
+
 							<Setter TargetName='CloseButton' Property='Visibility' Value='Visible'/>
 						</MultiTrigger>
 					</ControlTemplate.Triggers>

--- a/src/Tool.cs
+++ b/src/Tool.cs
@@ -4,20 +4,21 @@ using System.Windows.Controls;
 using System.Windows.Input;
 using System.Windows.Media;
 
-namespace Rooler {
-	public class Tool : ContentControl, IScreenService {
+namespace Rooler
+{
+	public class Tool : ContentControl, IScreenService
+	{
 
-		public Tool() {
-		}
-
-		public Tool(IScreenServiceHost host) {
+		public Tool(IScreenServiceHost host)
+		{
 			this.Host = host;
 			this.Focusable = true;
 
 			this.HorizontalContentAlignment = HorizontalAlignment.Stretch;
 			this.VerticalContentAlignment = VerticalAlignment.Stretch;
 
-			this.Loaded += delegate {
+			this.Loaded += delegate
+			{
 				this.Focus();
 			};
 
@@ -25,58 +26,69 @@ namespace Rooler {
 
 		protected IScreenServiceHost Host { get; set; }
 
-		public FrameworkElement Visual {
+		public FrameworkElement Visual
+		{
 			get { return this; }
 		}
 
 		public event EventHandler ServiceClosed;
-		public void CloseService() {
+		public void CloseService()
+		{
 			this.OnClosing();
 
 			if (this.ServiceClosed != null)
 				this.ServiceClosed(this, EventArgs.Empty);
 		}
 
-		public virtual void Update() {
-			
+		public virtual void Update()
+		{
+
 		}
 
 
 		private bool isFrozen = false;
-		public bool IsFrozen {
+		public bool IsFrozen
+		{
 			get { return this.isFrozen; }
 			private set { this.isFrozen = value; }
 		}
 
-		protected virtual void Freeze() {
+		protected virtual void Freeze()
+		{
 			this.IsFrozen = true;
 		}
 
 
-		protected override void OnKeyDown(KeyEventArgs e) {
-			switch (e.Key) {
-				case Key.Left: {
+		protected override void OnKeyDown(KeyEventArgs e)
+		{
+			switch (e.Key)
+			{
+				case Key.Left:
+					{
 						IntPoint cursorPos = NativeMethods.GetCursorPos();
 						cursorPos.X -= 1;
 						NativeMethods.SetCursorPos(cursorPos);
 					}
 					e.Handled = true;
 					break;
-				case Key.Right: {
+				case Key.Right:
+					{
 						IntPoint cursorPos = NativeMethods.GetCursorPos();
 						cursorPos.X += 1;
 						NativeMethods.SetCursorPos(cursorPos);
 					}
 					e.Handled = true;
 					break;
-				case Key.Up: {
+				case Key.Up:
+					{
 						IntPoint cursorPos = NativeMethods.GetCursorPos();
 						cursorPos.Y -= 1;
 						NativeMethods.SetCursorPos(cursorPos);
 					}
 					e.Handled = true;
 					break;
-				case Key.Down: {
+				case Key.Down:
+					{
 						IntPoint cursorPos = NativeMethods.GetCursorPos();
 						cursorPos.Y += 1;
 						NativeMethods.SetCursorPos(cursorPos);
@@ -87,7 +99,8 @@ namespace Rooler {
 			base.OnKeyDown(e);
 		}
 
-		protected virtual void OnClosing() {
+		protected virtual void OnClosing()
+		{
 		}
 	}
 }

--- a/src/VirtualizedScreenShot.cs
+++ b/src/VirtualizedScreenShot.cs
@@ -1,25 +1,22 @@
-﻿using System.Windows.Forms;
-using System;
-using System.Windows;
-namespace Rooler {
+﻿using System;
 
+namespace Rooler
+{
 	/// <summary>
 	/// On large screens we occasionally run out of memory when trying to take a screenshot
 	/// of the entire area. There are a couple of scenarios where we need to access large
 	/// areas of the screen, so this virtualizes the loading of that and only captures areas
 	/// on demand.
 	/// </summary>
-	public class VirtualizedScreenShot : IScreenShot {
-
+	public class VirtualizedScreenShot : IScreenShot
+	{
 		private ScreenShot[,] screenShots;
 		private IntRect bounds;
 		private int tileWidth = 200;
 		private int tileHeight = 200;
 
-
-		public VirtualizedScreenShot() {
-
-
+		public VirtualizedScreenShot()
+		{
 			this.bounds = ScreenShot.FullScreenBounds;
 
 			var countX = (int)Math.Ceiling(this.bounds.Width / (double)tileWidth) + 1;
@@ -28,70 +25,56 @@ namespace Rooler {
 			this.screenShots = new ScreenShot[countX, countY];
 		}
 
-		public int Left {
+		public int Left
+		{
 			get { return this.bounds.Left; }
 		}
 
-		public int Top {
+		public int Top
+		{
 			get { return this.bounds.Top; }
 		}
 
-		public int Right {
+		public int Right
+		{
 			get { return this.bounds.Right; }
 		}
 
-		public int Bottom {
+		public int Bottom
+		{
 			get { return this.bounds.Bottom; }
 		}
 
-		public int GetScreenPixel(int x, int y) {
+		public int GetScreenPixel(int x, int y)
+		{
 			x = x - this.bounds.Left;
 			y = y - this.bounds.Top;
 
 			return this.GetLocalPixel(x, y);
 		}
 
-		public int GetLocalPixel(int x, int y) {
+		public int GetLocalPixel(int x, int y)
+		{
 
 			int xIndex = x / this.tileWidth;
 			int yIndex = y / this.tileHeight;
 
 			ScreenShot ss = this.screenShots[xIndex, yIndex];
-			if (ss == null) {
-				try {
+			if (ss == null)
+			{
+				try
+				{
 					ss = new ScreenShot(new IntRect(xIndex * this.tileWidth + this.bounds.Left, yIndex * tileHeight + this.bounds.Top, tileWidth + 1, tileHeight + 1), false);
 					this.screenShots[xIndex, yIndex] = ss;
 				}
 				catch (Exception) { }
 			}
 
-			if (ss != null) {
-				//int x0 = ss.GetLocalPixel(x - xIndex * this.tileWidth, y - yIndex * this.tileHeight);
-				//int x1 = ss.GetLocalPixel((x + 1) - xIndex * this.tileWidth, y - yIndex * this.tileHeight);
-
+			if (ss != null)
+			{
 				return ss.GetLocalPixel(x - xIndex * this.tileWidth, y - yIndex * this.tileHeight);
 			}
 			return xIndex ^ yIndex;
 		}
-
-		//public ScreenShot GetTile(int x, int y) {
-		//    x = x - this.bounds.X;
-		//    y = y - this.bounds.Y;
-
-		//    int xIndex = x / this.tileWidth;
-		//    int yIndex = y / this.tileHeight + this.bounds.Y;
-
-		//    ScreenShot ss = null;// this.screenShots[xIndex, yIndex];
-		//    if (ss == null) {
-		//        try {
-		//            ss = new ScreenShot(new IntRect(xIndex * this.tileWidth + this.bounds.X, yIndex * tileHeight + this.bounds.Y, tileWidth + 1, tileHeight + 1), true);
-		//            //this.screenShots[xIndex, yIndex] = ss;
-		//        }
-		//        catch (Exception) { }
-		//    }
-
-		//    return ss;
-
-		//}
 	}
 }


### PR DESCRIPTION
This solves some problems:

1. The primary screen has a top/left position of 0, 0. In a multi-monitor setup, if there are screens to the left/above the primary screen, then those screens have negative coordinates. This corrects the calculations where needed. This fixes #5 
2. WPF uses coordinates and sizes based on a virtual 96dpi screen. If a user sets display scaling (ex. 150%), the virtual WPF pixels will not be the same as the native pixels. Besides fixing internal problems related to that, in those cases the "WPF" pixels and "native" pixels are both shown (ex. for bounds, spacing). The WPF value is shown first, with the native value in parentheses.
    * Note that WPF uses the display scaling of the primary screen everywhere. It is possible to have different values per screen, but WPF does not handle that case. In those cases, the "native" values for other screens will be incorrect.
3. At least in my system, using the DropShadowEffect causes access violations, so I removed it.